### PR TITLE
fix: add .js extensions to all relative ESM imports for Node ESM comp…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,6 +32,20 @@ jobs:
         working-directory: backend
         run: npx tsc --noEmit
 
+      - name: Check for directory imports missing index.js
+        working-directory: backend
+        run: |
+          FOUND=$(grep -rn "from ['\"]\..*[^/]['\"]" src --include="*.ts" | \
+            grep -v "\.js['\"]" | \
+            grep -v "\.ts['\"]" | \
+            grep -v "node_modules")
+          if [ -n "$FOUND" ]; then
+            echo "❌ Found imports that may resolve to a directory without /index.js:"
+            echo "$FOUND"
+            exit 1
+          fi
+          echo "✅ No bare directory imports found"
+
       - name: Check for circular dependencies
         working-directory: backend
         run: npx madge --circular --extensions js src/

--- a/backend/jest.config.mjs
+++ b/backend/jest.config.mjs
@@ -20,4 +20,7 @@ export default {
   transformIgnorePatterns: [
     'node_modules/(?!(supertest|natural|afinn-165)/)'
   ],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  }
 };

--- a/backend/src/controllers/market/industryController.ts
+++ b/backend/src/controllers/market/industryController.ts
@@ -1,13 +1,13 @@
-import { catchAsync } from "../../utils/errorUtils";
+import { catchAsync } from "../../utils/errorUtils.js";
 import { Request, Response } from "express";
-import Industry from "../../models/market/industryModel";
-import { IndustryInterface, IndustryEmbeddingData, CreateIndustryPayload, UpdateIndustryPayload } from "../../types/industry.types";
+import Industry from "../../models/market/industryModel.js";
+import { IndustryInterface, IndustryEmbeddingData, CreateIndustryPayload, UpdateIndustryPayload } from "../../types/industry.types.js";
 import { Types } from "mongoose";
-import { ApiQueueResponse } from "../../types/apiResponse.types";
-import { STATUS_MESSAGES } from "../../constants";
+import { ApiQueueResponse } from "../../types/apiResponse.types.js";
+import { STATUS_MESSAGES } from "../../constants.js";
 import * as IndustryRepo from '../../repositories/market/industryRepositories';
 import * as IndustryService from '../../services/market/industryService';
-import { sendTypedResponse } from "../../utils/sendTypedResponse";
+import { sendTypedResponse } from "../../utils/sendTypedResponse.js";
 
 export const getIndustryById = catchAsync(async (req: Request, res: Response) => {
     const { id } = req.params as { id: string };

--- a/backend/src/controllers/market/industryController.ts
+++ b/backend/src/controllers/market/industryController.ts
@@ -5,8 +5,8 @@ import { IndustryInterface, IndustryEmbeddingData, CreateIndustryPayload, Update
 import { Types } from "mongoose";
 import { ApiQueueResponse } from "../../types/apiResponse.types.js";
 import { STATUS_MESSAGES } from "../../constants.js";
-import * as IndustryRepo from '../../repositories/market/industryRepositories';
-import * as IndustryService from '../../services/market/industryService';
+import * as IndustryRepo from '../../repositories/market/industryRepositories.js';
+import * as IndustryService from '../../services/market/industryService.js';
 import { sendTypedResponse } from "../../utils/sendTypedResponse.js";
 
 export const getIndustryById = catchAsync(async (req: Request, res: Response) => {

--- a/backend/src/controllers/market/jobTitleController.ts
+++ b/backend/src/controllers/market/jobTitleController.ts
@@ -4,7 +4,6 @@ import * as JobTitleRepo from '../../repositories/market/jobTitleRepositories.js
 import * as JobTitleService from '../../services/market/jobTitleService.js'
 import { catchAsync } from "../../utils/errorUtils.js"
 import { sendResponse, STATUS_MESSAGES } from "../../constants.js"
-import type { ImportanceLevel } from "../../../../shared/constants/jobsAndIndustries/constants.js"
 
 export const getJobTitleById = catchAsync(async (req: Request, res: Response) => {
     const { id } = req.params as { id: string };

--- a/backend/src/controllers/market/jobTitleController.ts
+++ b/backend/src/controllers/market/jobTitleController.ts
@@ -2,9 +2,9 @@ import { Types } from "mongoose"
 import { Request, Response } from "express"
 import * as JobTitleRepo from '../../repositories/market/jobTitleRepositories'
 import * as JobTitleService from '../../services/market/jobTitleService'
-import { catchAsync } from "../../utils/errorUtils"
-import { sendResponse, STATUS_MESSAGES } from "../../constants"
-import type { ImportanceLevel } from "../../../../shared/constants/jobsAndIndustries/constants"
+import { catchAsync } from "../../utils/errorUtils.js"
+import { sendResponse, STATUS_MESSAGES } from "../../constants.js"
+import type { ImportanceLevel } from "../../../../shared/constants/jobsAndIndustries/constants.js"
 
 export const getJobTitleById = catchAsync(async (req: Request, res: Response) => {
     const { id } = req.params as { id: string };

--- a/backend/src/controllers/market/jobTitleController.ts
+++ b/backend/src/controllers/market/jobTitleController.ts
@@ -1,7 +1,7 @@
 import { Types } from "mongoose"
 import { Request, Response } from "express"
-import * as JobTitleRepo from '../../repositories/market/jobTitleRepositories'
-import * as JobTitleService from '../../services/market/jobTitleService'
+import * as JobTitleRepo from '../../repositories/market/jobTitleRepositories.js'
+import * as JobTitleService from '../../services/market/jobTitleService.js'
 import { catchAsync } from "../../utils/errorUtils.js"
 import { sendResponse, STATUS_MESSAGES } from "../../constants.js"
 import type { ImportanceLevel } from "../../../../shared/constants/jobsAndIndustries/constants.js"

--- a/backend/src/controllers/market/locationController.ts
+++ b/backend/src/controllers/market/locationController.ts
@@ -1,12 +1,12 @@
-import { catchAsync } from "../../utils/errorUtils";
+import { catchAsync } from "../../utils/errorUtils.js";
 import { Request, Response } from "express";
 import * as LocationRepo from '../../repositories/market/locationRepositories'
 import * as LocationService from '../../services/market/locationService'
 import { Types } from "mongoose";
-import { STATUS_MESSAGES } from "../../constants";
-import { sendTypedResponse } from "../../utils/sendTypedResponse";
-import { CreateLocationPayload, LocationEmbeddingData, LocationInterface, UpdateLocationPayload } from "../../types/location.types";
-import { ApiQueueResponse } from "../../types/apiResponse.types";
+import { STATUS_MESSAGES } from "../../constants.js";
+import { sendTypedResponse } from "../../utils/sendTypedResponse.js";
+import { CreateLocationPayload, LocationEmbeddingData, LocationInterface, UpdateLocationPayload } from "../../types/location.types.js";
+import { ApiQueueResponse } from "../../types/apiResponse.types.js";
 
 export const getLocationByIdController = catchAsync(async(req: Request, res: Response) => {
     const { id } = req.params as { id: string };

--- a/backend/src/controllers/market/locationController.ts
+++ b/backend/src/controllers/market/locationController.ts
@@ -1,7 +1,7 @@
 import { catchAsync } from "../../utils/errorUtils.js";
 import { Request, Response } from "express";
-import * as LocationRepo from '../../repositories/market/locationRepositories'
-import * as LocationService from '../../services/market/locationService'
+import * as LocationRepo from '../../repositories/market/locationRepositories.js'
+import * as LocationService from '../../services/market/locationService.js'
 import { Types } from "mongoose";
 import { STATUS_MESSAGES } from "../../constants.js";
 import { sendTypedResponse } from "../../utils/sendTypedResponse.js";

--- a/backend/src/controllers/market/skillController.ts
+++ b/backend/src/controllers/market/skillController.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from "express";
-import * as SkillService from '../../services/market/skillService';
-import * as SkillRepo from '../../repositories/market/skillRepositories';
-import { catchAsync } from '../../utils/errorUtils';
-import { sendResponse, STATUS_MESSAGES } from '../../constants';
+import * as SkillService from '../../services/market/skillService.js';
+import * as SkillRepo from '../../repositories/market/skillRepositories.js';
+import { catchAsync } from '../../utils/errorUtils.js';
+import { sendResponse, STATUS_MESSAGES } from '../../constants.js';
 import { Types } from "mongoose";
 
 // ============================================

--- a/backend/src/infrastructure/embedding/backfill/embeddingBackfill.ts
+++ b/backend/src/infrastructure/embedding/backfill/embeddingBackfill.ts
@@ -1,11 +1,11 @@
 import { Types } from 'mongoose';
-import { industryEmbeddingQueue, jobTitleEmbeddingQueue, locationEmbeddingQueue, skillEmbeddingQueue } from '../../../queues';
-import { upsertSkillEmbeddingService } from '../../../services/market/skillService';
-import { upsertJobTitleEmbeddingService } from '../../../services/market/jobTitleService';
-import { upsertLocationEmbeddingService } from '../../../services/market/locationService';
-import { upsertIndustryEmbeddingService } from '../../../services/market/industryService';
-import logger from '../../../utils/logger';
-import { safeQueueOperation } from '../../../utils/queueUtils';
+import { industryEmbeddingQueue, jobTitleEmbeddingQueue, locationEmbeddingQueue, skillEmbeddingQueue } from '../../../queues.js';
+import { upsertSkillEmbeddingService } from '../../../services/market/skillService.js';
+import { upsertJobTitleEmbeddingService } from '../../../services/market/jobTitleService.js';
+import { upsertLocationEmbeddingService } from '../../../services/market/locationService.js';
+import { upsertIndustryEmbeddingService } from '../../../services/market/industryService.js';
+import logger from '../../../utils/logger.js';
+import { safeQueueOperation } from '../../../utils/queueUtils.js';
 
 
 // --- Types ---

--- a/backend/src/infrastructure/embedding/backfill/embeddingBackfill.ts
+++ b/backend/src/infrastructure/embedding/backfill/embeddingBackfill.ts
@@ -1,5 +1,5 @@
 import { Types } from 'mongoose';
-import { industryEmbeddingQueue, jobTitleEmbeddingQueue, locationEmbeddingQueue, skillEmbeddingQueue } from '../../../queues.js';
+import { industryEmbeddingQueue, jobTitleEmbeddingQueue, locationEmbeddingQueue, skillEmbeddingQueue } from '../../../queues/index.js';
 import { upsertSkillEmbeddingService } from '../../../services/market/skillService.js';
 import { upsertJobTitleEmbeddingService } from '../../../services/market/jobTitleService.js';
 import { upsertLocationEmbeddingService } from '../../../services/market/locationService.js';

--- a/backend/src/infrastructure/embedding/core/executeEmbeddingFallback.ts
+++ b/backend/src/infrastructure/embedding/core/executeEmbeddingFallback.ts
@@ -1,5 +1,5 @@
-import logger from "../../../utils/logger";
-import { safeQueueOperation } from "../../../utils/queueUtils";
+import logger from "../../../utils/logger.js";
+import { safeQueueOperation } from "../../../utils/queueUtils.js";
 
 type ExecutionOptions<T> = {
     queueFn: () => Promise<{ jobId: string }>;

--- a/backend/src/infrastructure/embedding/core/executeEmbeddingPipeline.ts
+++ b/backend/src/infrastructure/embedding/core/executeEmbeddingPipeline.ts
@@ -1,9 +1,9 @@
 import { Types } from 'mongoose';
-import logger from '../../../utils/logger';
-import { embeddingRegistry } from '../registry/embeddingRegistry';
-import { EmbeddingEntityKey } from '../registry/embeddingRegistry.types';
-import { PythonResponse, runPythonTyped } from '../../../types/python.types';
-import { QueueJob } from '../../../types/queues.types';
+import logger from '../../../utils/logger.js';
+import { embeddingRegistry } from '../registry/embeddingRegistry.js';
+import { EmbeddingEntityKey } from '../registry/embeddingRegistry.types.js';
+import { PythonResponse, runPythonTyped } from '../../../types/python.types.js';
+import { QueueJob } from '../../../types/queues.types.js';
 
 
 interface PipelineOptions<TKey extends EmbeddingEntityKey> {

--- a/backend/src/infrastructure/embedding/core/orchestrateEmbedding.ts
+++ b/backend/src/infrastructure/embedding/core/orchestrateEmbedding.ts
@@ -1,5 +1,5 @@
-import logger from "../../../utils/logger"
-import { executeEmbeddingFallback } from "./executeEmbeddingFallback"
+import logger from "../../../utils/logger.js"
+import { executeEmbeddingFallback } from "./executeEmbeddingFallback.js"
 
 interface OrchestrationOptions<T> {
     invalidateCache?: boolean;

--- a/backend/src/infrastructure/embedding/registry/embeddingRegistry.ts
+++ b/backend/src/infrastructure/embedding/registry/embeddingRegistry.ts
@@ -1,5 +1,5 @@
 import { Types } from "mongoose";
-import { createEmbeddingQueueRunner } from "../core/createEmbeddingQueueRunner";
+import { createEmbeddingQueueRunner } from "../core/createEmbeddingQueueRunner.js";
 import {
     resumeEmbeddingQueue,
     skillEmbeddingQueue,
@@ -7,56 +7,56 @@ import {
     locationEmbeddingQueue,
     industryEmbeddingQueue,
     jobEmbeddingQueue,
-} from "../../../queues";
-import { EmbeddingEntityConfig } from "./embeddingRegistry.types";
+} from "../../../queues.js";
+import { EmbeddingEntityConfig } from "./embeddingRegistry.types.js";
 
 // ─── Resume ───────────────────────────────────────────────────────────────────
-import { JobPostingEmbeddingsDocument, MarketEmbeddingUpdate, ResumeEmbeddingsDocument } from "../../../types/embeddings.types";
+import { JobPostingEmbeddingsDocument, MarketEmbeddingUpdate, ResumeEmbeddingsDocument } from "../../../types/embeddings.types.js";
 import {
     getResumeEmbeddingsRepo,
     createResumeEmbeddingRepo,
     updateResumeEmbeddingRepo,
-} from "../../../repositories/resumes/resumeEmbeddingRepository";
-import { upsertResumeEmbedding } from "../../../services/resumes/resumeEmbeddingService";
-import { generateResumeScoreService } from "../../../services/resumes/resumeScoreService";
+} from "../../../repositories/resumes/resumeEmbeddingRepository.js";
+import { upsertResumeEmbedding } from "../../../services/resumes/resumeEmbeddingService.js";
+import { generateResumeScoreService } from "../../../services/resumes/resumeScoreService.js";
 
 // ─── Skill ────────────────────────────────────────────────────────────────────
-import { SkillDocument } from "../../../models/market/skillModel";
+import { SkillDocument } from "../../../models/market/skillModel.js";
 import {
     getSkillEmbeddingRepository,
     updateSkillEmbeddingRepository,
-} from "../../../repositories/market/skillRepositories";
-import { upsertSkillEmbeddingService } from "../../../services/market/skillService";
+} from "../../../repositories/market/skillRepositories.js";
+import { upsertSkillEmbeddingService } from "../../../services/market/skillService.js";
 
 // ─── JobTitle ─────────────────────────────────────────────────────────────────
-import { JobTitleEmbeddingData } from "../../../types/jobTitle.types";
+import { JobTitleEmbeddingData } from "../../../types/jobTitle.types.js";
 import {
     getJobTitleEmbeddingsByIdRepository,
     updateJobTitleEmbeddingRepository,
-} from "../../../repositories/market/jobTitleRepositories";
-import { upsertJobTitleEmbeddingService } from "../../../services/market/jobTitleService";
+} from "../../../repositories/market/jobTitleRepositories.js";
+import { upsertJobTitleEmbeddingService } from "../../../services/market/jobTitleService.js";
 
 // ─── Location ─────────────────────────────────────────────────────────────────
-import { LocationEmbeddingData } from "../../../types/location.types";
+import { LocationEmbeddingData } from "../../../types/location.types.js";
 import {
     getLocationEmbeddingByIdRepository,
     updateLocationEmbeddingRepository,
-} from "../../../repositories/market/locationRepositories";
-import { upsertLocationEmbeddingService } from "../../../services/market/locationService";
+} from "../../../repositories/market/locationRepositories.js";
+import { upsertLocationEmbeddingService } from "../../../services/market/locationService.js";
 
 // ─── Industry ─────────────────────────────────────────────────────────────────
-import { IndustryEmbeddingData } from "../../../types/industry.types";
+import { IndustryEmbeddingData } from "../../../types/industry.types.js";
 import {
     getIndustryEmbeddingByIdRepository,
     updateIndustryEmbeddingRepository,
-} from "../../../repositories/market/industryRepositories";
-import { upsertIndustryEmbeddingService } from "../../../services/market/industryService";
+} from "../../../repositories/market/industryRepositories.js";
+import { upsertIndustryEmbeddingService } from "../../../services/market/industryService.js";
 
-import logger from "../../../utils/logger";
-import { QueueJob } from "../../../types/queues.types";
-import { createJobEmbeddingRepo, getJobEmbeddingRepo, updateJobEmbeddingRepo } from "../../../repositories/jobPostings/jobEmbeddingRepositories";
-import { getJobPostingEmbeddingService, upsertJobPostingEmbeddingService } from "../../../services/jobPostings/jobPostingEmbeddingService";
-import { PythonEmit } from "../../../types/python.types";
+import logger from "../../../utils/logger.js";
+import { QueueJob } from "../../../types/queues.types.js";
+import { createJobEmbeddingRepo, getJobEmbeddingRepo, updateJobEmbeddingRepo } from "../../../repositories/jobPostings/jobEmbeddingRepositories.js";
+import { getJobPostingEmbeddingService, upsertJobPostingEmbeddingService } from "../../../services/jobPostings/jobPostingEmbeddingService.js";
+import { PythonEmit } from "../../../types/python.types.js";
 
 const isProd = process.env.NODE_ENV === 'production';
 

--- a/backend/src/infrastructure/embedding/registry/embeddingRegistry.ts
+++ b/backend/src/infrastructure/embedding/registry/embeddingRegistry.ts
@@ -7,7 +7,7 @@ import {
     locationEmbeddingQueue,
     industryEmbeddingQueue,
     jobEmbeddingQueue,
-} from "../../../queues.js";
+} from "../../../queues/index.js";
 import { EmbeddingEntityConfig } from "./embeddingRegistry.types.js";
 
 // ─── Resume ───────────────────────────────────────────────────────────────────

--- a/backend/src/infrastructure/embedding/registry/embeddingRegistry.types.ts
+++ b/backend/src/infrastructure/embedding/registry/embeddingRegistry.types.ts
@@ -1,6 +1,6 @@
 import { Types } from "mongoose";
-import { QueueJob } from "../../../types/queues.types";
-import { embeddingRegistry } from "./embeddingRegistry";
+import { QueueJob } from "../../../types/queues.types.js";
+import { embeddingRegistry } from "./embeddingRegistry.js";
 
 /**
  * Repository adapter for embedding persistence.

--- a/backend/src/infrastructure/embedding/workers/createEmbeddingWorker.ts
+++ b/backend/src/infrastructure/embedding/workers/createEmbeddingWorker.ts
@@ -1,11 +1,11 @@
 import { Queue, Worker, Job } from 'bullmq';
 import { Types } from 'mongoose';
-import logger from '../../../utils/logger';
-import { embeddingRegistry } from '../registry/embeddingRegistry';
-import { executeEmbeddingPipeline } from '../core/executeEmbeddingPipeline';
+import logger from '../../../utils/logger.js';
+import { embeddingRegistry } from '../registry/embeddingRegistry.js';
+import { executeEmbeddingPipeline } from '../core/executeEmbeddingPipeline.js';
 import { EmbeddingEntityKey } from '../registry/embeddingRegistry.types.js';
-import { getIO } from '../../../sockets';
-import { getSocketId } from '../../../sockets/presence';
+import { getIO } from '../../../sockets.js';
+import { getSocketId } from '../../../sockets/presence.js';
 
 interface WorkerConfig {
     entityKey: EmbeddingEntityKey;

--- a/backend/src/infrastructure/embedding/workers/createEmbeddingWorker.ts
+++ b/backend/src/infrastructure/embedding/workers/createEmbeddingWorker.ts
@@ -4,7 +4,7 @@ import logger from '../../../utils/logger.js';
 import { embeddingRegistry } from '../registry/embeddingRegistry.js';
 import { executeEmbeddingPipeline } from '../core/executeEmbeddingPipeline.js';
 import { EmbeddingEntityKey } from '../registry/embeddingRegistry.types.js';
-import { getIO } from '../../../sockets.js';
+import { getIO } from '../../../sockets/index.js';
 import { getSocketId } from '../../../sockets/presence.js';
 
 interface WorkerConfig {

--- a/backend/src/infrastructure/embedding/workers/workersRegistry.ts
+++ b/backend/src/infrastructure/embedding/workers/workersRegistry.ts
@@ -1,5 +1,5 @@
 import { Queue } from "bullmq";
-import { redisConnection } from "../../../config/queue.config";
+import { redisConnection } from "../../../config/queue.config.js";
 
 import {
     resumeEmbeddingQueue,
@@ -13,12 +13,12 @@ import {
     locationEmbeddingDLQ,
     industryEmbeddingDLQ,
     jobEmbeddingQueue,
-} from "../../../queues";
+} from "../../../queues.js";
 
-import { embeddingRegistry } from "../registry/embeddingRegistry";
+import { embeddingRegistry } from "../registry/embeddingRegistry.js";
 import { createEmbeddingWorker } from "./createEmbeddingWorker.js";
 import { EmbeddingEntityKey } from "../registry/embeddingRegistry.types.js";
-import logger from "../../../utils/logger";
+import logger from "../../../utils/logger.js";
 
 /**
  * Queue bindings

--- a/backend/src/infrastructure/embedding/workers/workersRegistry.ts
+++ b/backend/src/infrastructure/embedding/workers/workersRegistry.ts
@@ -13,7 +13,7 @@ import {
     locationEmbeddingDLQ,
     industryEmbeddingDLQ,
     jobEmbeddingQueue,
-} from "../../../queues.js";
+} from "../../../queues/index.js";
 
 import { embeddingRegistry } from "../registry/embeddingRegistry.js";
 import { createEmbeddingWorker } from "./createEmbeddingWorker.js";

--- a/backend/src/jobs/processes/generateEmbeddings.ts
+++ b/backend/src/jobs/processes/generateEmbeddings.ts
@@ -1,4 +1,4 @@
-import { embeddingWorkers, shutdownWorkers } from "../../infrastructure/embedding/workers/workersRegistry";
+import { embeddingWorkers, shutdownWorkers } from "../../infrastructure/embedding/workers/workersRegistry.js";
 
 import logger from "../../utils/logger.js";
 

--- a/backend/src/middleware/resourceCheck/jobTitle.ts
+++ b/backend/src/middleware/resourceCheck/jobTitle.ts
@@ -1,7 +1,7 @@
 import { Types } from "mongoose";
-import { catchAsync } from "../../utils/errorUtils";
+import { catchAsync } from "../../utils/errorUtils.js";
 import { Request, Response, NextFunction } from "express";
-import JobTitle from "../../models/market/jobTitleModel";
+import JobTitle from "../../models/market/jobTitleModel.js";
 import { NotFoundError } from "../errorHandler.js";
 
 export const checkIfJobTitleExistsById = catchAsync(async (req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/middleware/resourceCheck/skill.ts
+++ b/backend/src/middleware/resourceCheck/skill.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { catchAsync } from "../../utils/errorUtils";
-import Skill from "../../models/market/skillModel";
+import { catchAsync } from "../../utils/errorUtils.js";
+import Skill from "../../models/market/skillModel.js";
 import { NotFoundError } from "../errorHandler.js";
 
 export const checkIfSkillExistsById = catchAsync(async (req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/models/market/industryModel.ts
+++ b/backend/src/models/market/industryModel.ts
@@ -1,6 +1,6 @@
 import mongoose, { Document, HydratedDocument } from "mongoose";
-import { INDUSTRY_NAMES } from "../../../../shared/constants/jobsAndIndustries/constants";
-import { IndustryInterface } from "../../types/industry.types"; // Import the correct types
+import { INDUSTRY_NAMES } from "../../../../shared/constants/jobsAndIndustries/constants.js";
+import { IndustryInterface } from "../../types/industry.types.js"; // Import the correct types
 
 export type IndustryDocument = HydratedDocument<IndustryInterface>;
 

--- a/backend/src/models/market/jobTitleModel.ts
+++ b/backend/src/models/market/jobTitleModel.ts
@@ -1,6 +1,6 @@
 import mongoose, { Document, Schema } from "mongoose";
-import { INDUSTRY_NAMES } from "../../../../shared/constants/jobsAndIndustries/constants";
-import { JobTitleInterface } from "../../types/jobTitle.types";
+import { INDUSTRY_NAMES } from "../../../../shared/constants/jobsAndIndustries/constants.js";
+import { JobTitleInterface } from "../../types/jobTitle.types.js";
 import { HydratedDocument } from "mongoose";
 
 export type JobTitleDocument = HydratedDocument<JobTitleInterface>;

--- a/backend/src/models/market/locationModel.ts
+++ b/backend/src/models/market/locationModel.ts
@@ -1,6 +1,6 @@
 import mongoose from "mongoose";
 import { HydratedDocument } from "mongoose";
-import { LocationInterface } from "../../types/location.types";
+import { LocationInterface } from "../../types/location.types.js";
 
 export type LocationDocument = HydratedDocument<LocationInterface>
 

--- a/backend/src/models/market/skillModel.ts
+++ b/backend/src/models/market/skillModel.ts
@@ -1,5 +1,5 @@
 import mongoose, { HydratedDocument } from "mongoose";
-import { SkillInterface } from "../../types/skill.types";
+import { SkillInterface } from "../../types/skill.types.js";
 
 export type SkillDocument = HydratedDocument<SkillInterface>;
 

--- a/backend/src/repositories/market/industryRepositories.ts
+++ b/backend/src/repositories/market/industryRepositories.ts
@@ -1,6 +1,6 @@
-import Industry from "../../models/market/industryModel";
-import { MarketEmbeddingUpdate } from "../../types/embeddings.types";
-import { IndustryInterface, CreateIndustryPayload, UpdateIndustryPayload } from "../../types/industry.types";
+import Industry from "../../models/market/industryModel.js";
+import { MarketEmbeddingUpdate } from "../../types/embeddings.types.js";
+import { IndustryInterface, CreateIndustryPayload, UpdateIndustryPayload } from "../../types/industry.types.js";
 import { Types } from "mongoose";
 
 /**

--- a/backend/src/repositories/market/jobTitleRepositories.ts
+++ b/backend/src/repositories/market/jobTitleRepositories.ts
@@ -1,8 +1,8 @@
 // repositories/jobTitleRepository.ts
-import type { ImportanceLevel } from "../../../../shared/constants/jobsAndIndustries/constants";
-import JobTitle from "../../models/market/jobTitleModel";
-import { MarketEmbeddingUpdate } from "../../types/embeddings.types";
-import { JobTitleInterface, CreateJobTitlePayload, UpdateJobTitlePayload } from "../../types/jobTitle.types";
+import type { ImportanceLevel } from "../../../../shared/constants/jobsAndIndustries/constants.js";
+import JobTitle from "../../models/market/jobTitleModel.js";
+import { MarketEmbeddingUpdate } from "../../types/embeddings.types.js";
+import { JobTitleInterface, CreateJobTitlePayload, UpdateJobTitlePayload } from "../../types/jobTitle.types.js";
 import { Types } from "mongoose";
 
 /**

--- a/backend/src/repositories/market/locationRepositories.ts
+++ b/backend/src/repositories/market/locationRepositories.ts
@@ -1,7 +1,7 @@
 // repositories/locationRepository.ts
-import Location from "../../models/market/locationModel";
-import { MarketEmbeddingUpdate } from "../../types/embeddings.types";
-import { LocationInterface, CreateLocationPayload, UpdateLocationPayload } from "../../types/location.types";
+import Location from "../../models/market/locationModel.js";
+import { MarketEmbeddingUpdate } from "../../types/embeddings.types.js";
+import { LocationInterface, CreateLocationPayload, UpdateLocationPayload } from "../../types/location.types.js";
 import { Types } from "mongoose";
 
 /**

--- a/backend/src/repositories/market/skillRepositories.ts
+++ b/backend/src/repositories/market/skillRepositories.ts
@@ -1,8 +1,8 @@
 // repositories/skillRepository.ts
-import Skill from "../../models/market/skillModel";
-import type { SkillDocument } from "../../models/market/skillModel";
-import { MarketEmbeddingUpdate } from "../../types/embeddings.types";
-import { SkillInterface, CreateSkillPayload, UpdateSkillPayload } from "../../types/skill.types";
+import Skill from "../../models/market/skillModel.js";
+import type { SkillDocument } from "../../models/market/skillModel.js";
+import { MarketEmbeddingUpdate } from "../../types/embeddings.types.js";
+import { SkillInterface, CreateSkillPayload, UpdateSkillPayload } from "../../types/skill.types.js";
 import { Types } from "mongoose";
 
 /**

--- a/backend/src/routes/market/industryRoutes.ts
+++ b/backend/src/routes/market/industryRoutes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import * as IndustryController from '../../controllers/market/industryController'
+import * as IndustryController from '../../controllers/market/industryController.js'
 
 const router = express.Router();
 

--- a/backend/src/routes/market/jobTitleRoutes.ts
+++ b/backend/src/routes/market/jobTitleRoutes.ts
@@ -2,7 +2,7 @@ import express from "express"
 import { authenticate } from "../../middleware/authentication/authenticate.js";
 import { requireRole } from "../../middleware/authorization/roleAuthorization.js";
 import { validate } from "../../middleware/validation.js";
-import * as JobTitleController from '../../controllers/market/jobTitleController.js'
+import * as JobTitleController from "../../controllers/market/jobTitleController.js"
 import { createJobTitleSchema, updateJobTitleSchema } from "../../validators/jobTitleValidator.js";
 import { checkIfJobTitleExistsById } from "../../middleware/resourceCheck/jobTitle.js";
 

--- a/backend/src/routes/market/jobTitleRoutes.ts
+++ b/backend/src/routes/market/jobTitleRoutes.ts
@@ -1,10 +1,10 @@
 import express from "express"
-import { authenticate } from "../../middleware/authentication/authenticate";
-import { requireRole } from "../../middleware/authorization/roleAuthorization";
-import { validate } from "../../middleware/validation";
+import { authenticate } from "../../middleware/authentication/authenticate.js";
+import { requireRole } from "../../middleware/authorization/roleAuthorization.js";
+import { validate } from "../../middleware/validation.js";
 import * as JobTitleController from '../../controllers/market/jobTitleController'
-import { createJobTitleSchema, updateJobTitleSchema } from "../../validators/jobTitleValidator";
-import { checkIfJobTitleExistsById } from "../../middleware/resourceCheck/jobTitle";
+import { createJobTitleSchema, updateJobTitleSchema } from "../../validators/jobTitleValidator.js";
+import { checkIfJobTitleExistsById } from "../../middleware/resourceCheck/jobTitle.js";
 
 const router = express.Router();
 

--- a/backend/src/routes/market/jobTitleRoutes.ts
+++ b/backend/src/routes/market/jobTitleRoutes.ts
@@ -2,7 +2,7 @@ import express from "express"
 import { authenticate } from "../../middleware/authentication/authenticate.js";
 import { requireRole } from "../../middleware/authorization/roleAuthorization.js";
 import { validate } from "../../middleware/validation.js";
-import * as JobTitleController from '../../controllers/market/jobTitleController'
+import * as JobTitleController from '../../controllers/market/jobTitleController.js'
 import { createJobTitleSchema, updateJobTitleSchema } from "../../validators/jobTitleValidator.js";
 import { checkIfJobTitleExistsById } from "../../middleware/resourceCheck/jobTitle.js";
 

--- a/backend/src/routes/market/locationRoutes.ts
+++ b/backend/src/routes/market/locationRoutes.ts
@@ -1,9 +1,9 @@
 import express from "express";
-import * as LocationController from "../../controllers/market/locationController";
-import { authenticate } from "../../middleware/authentication/authenticate";
-import { requireRole } from "../../middleware/authorization/roleAuthorization";
-import { validate } from "../../middleware/validation";
-import { createLocationSchema } from "../../validators/locationValidator";
+import * as LocationController from "../../controllers/market/locationController.js";
+import { authenticate } from "../../middleware/authentication/authenticate.js";
+import { requireRole } from "../../middleware/authorization/roleAuthorization.js";
+import { validate } from "../../middleware/validation.js";
+import { createLocationSchema } from "../../validators/locationValidator.js";
 
 const router = express.Router();
 

--- a/backend/src/routes/market/skillRoutes.ts
+++ b/backend/src/routes/market/skillRoutes.ts
@@ -1,10 +1,10 @@
 import express from "express"
-import * as SkillController from "../../controllers/market/skillController";
-import { authenticate } from "../../middleware/authentication/authenticate";
-import { requireRole } from "../../middleware/authorization/roleAuthorization";
-import { validate } from "../../middleware/validation";
-import { createSkillSchema, updateSkillSchema } from "../../validators/skillValidator";
-import { checkIfSkillExistsById } from "../../middleware/resourceCheck/skill";
+import * as SkillController from "../../controllers/market/skillController.js";
+import { authenticate } from "../../middleware/authentication/authenticate.js";
+import { requireRole } from "../../middleware/authorization/roleAuthorization.js";
+import { validate } from "../../middleware/validation.js";
+import { createSkillSchema, updateSkillSchema } from "../../validators/skillValidator.js";
+import { checkIfSkillExistsById } from "../../middleware/resourceCheck/skill.js";
 
 const router = express.Router();
 

--- a/backend/src/scripts/seedMarketData.ts
+++ b/backend/src/scripts/seedMarketData.ts
@@ -1,13 +1,13 @@
 // scripts/seedMarketData.ts
 import mongoose from "mongoose";
 import dotenv from "dotenv";
-import Industry from "../models/market/industryModel";
-import Location from "../models/market/locationModel";
-import Skill from "../models/market/skillModel";
-import JobTitle from "../models/market/jobTitleModel";
-import { INDUSTRY_CHOICES } from "../../../shared/constants/jobsAndIndustries/constants";
-import type { IndustryName } from "../types/industry.types";
-import { SeniorityLevel } from "../types/industry.types";
+import Industry from "../models/market/industryModel.js";
+import Location from "../models/market/locationModel.js";
+import Skill from "../models/market/skillModel.js";
+import JobTitle from "../models/market/jobTitleModel.js";
+import { INDUSTRY_CHOICES } from "../../../shared/constants/jobsAndIndustries/constants.js";
+import type { IndustryName } from "../types/industry.types.js";
+import { SeniorityLevel } from "../types/industry.types.js";
 dotenv.config({ path: '.env.dev' });
 
 

--- a/backend/src/services/jobPostings/jobPostingEmbeddingService.ts
+++ b/backend/src/services/jobPostings/jobPostingEmbeddingService.ts
@@ -2,10 +2,10 @@ import { createJobEmbeddingRepo, getJobEmbeddingRepo } from "../../repositories/
 import logger from "../../utils/logger.js";
 import { runPython } from "../../infrastructure/python/pythonRunner.js";
 import { Types } from "mongoose";
-import { orchestrateEmbeddings } from "../../infrastructure/embedding/core/orchestrateEmbedding";
+import { orchestrateEmbeddings } from "../../infrastructure/embedding/core/orchestrateEmbedding.js";
 import { JobPostingEmbeddingsDocument } from "../../types/embeddings.types.js";
-import { embeddingRegistry } from "../../infrastructure/embedding/registry/embeddingRegistry";
-import { executeEmbeddingPipeline } from "../../infrastructure/embedding/core/executeEmbeddingPipeline";
+import { embeddingRegistry } from "../../infrastructure/embedding/registry/embeddingRegistry.js";
+import { executeEmbeddingPipeline } from "../../infrastructure/embedding/core/executeEmbeddingPipeline.js";
 import { QueueJob } from "../../types/queues.types.js";
 import { PythonEmit } from "../../types/python.types.js";
 

--- a/backend/src/services/market/industryService.ts
+++ b/backend/src/services/market/industryService.ts
@@ -1,14 +1,14 @@
-import { IndustryEmbeddingData, CreateIndustryPayload, UpdateIndustryPayload } from '../../types/industry.types';
+import { IndustryEmbeddingData, CreateIndustryPayload, UpdateIndustryPayload } from '../../types/industry.types.js';
 import { Types } from 'mongoose';
-import { QueueJob } from '../../types/queues.types';
-import logger from '../../utils/logger';
-import { PythonEmit, PythonResponse, runPythonTyped } from '../../types/python.types';
-import * as IndustryRepo from '../../repositories/market/industryRepositories';
-import { isEmbeddingStale, isValidEmbedding } from '../../utils/embeddings/embeddingValidationUtils';
-import Industry from '../../models/market/industryModel';
-import { embeddingRegistry } from '../../infrastructure/embedding/registry/embeddingRegistry';
-import { orchestrateEmbeddings } from '../../infrastructure/embedding/core/orchestrateEmbedding';
-import { executeEmbeddingPipeline } from '../../infrastructure/embedding/core/executeEmbeddingPipeline';
+import { QueueJob } from '../../types/queues.types.js';
+import logger from '../../utils/logger.js';
+import { PythonEmit, PythonResponse, runPythonTyped } from '../../types/python.types.js';
+import * as IndustryRepo from '../../repositories/market/industryRepositories.js';
+import { isEmbeddingStale, isValidEmbedding } from '../../utils/embeddings/embeddingValidationUtils.js';
+import Industry from '../../models/market/industryModel.js';
+import { embeddingRegistry } from '../../infrastructure/embedding/registry/embeddingRegistry.js';
+import { orchestrateEmbeddings } from '../../infrastructure/embedding/core/orchestrateEmbedding.js';
+import { executeEmbeddingPipeline } from '../../infrastructure/embedding/core/executeEmbeddingPipeline.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/backend/src/services/market/jobTitleService.ts
+++ b/backend/src/services/market/jobTitleService.ts
@@ -1,15 +1,15 @@
-import * as JobTitleRepo from '../../repositories/market/jobTitleRepositories';
+import * as JobTitleRepo from '../../repositories/market/jobTitleRepositories.js';
 import { Types } from 'mongoose';
-import { isEmbeddingStale, isValidEmbedding } from '../../utils/embeddings/embeddingValidationUtils';
-import logger from '../../utils/logger';
-import { QueueJob } from '../../types/queues.types';
-import JobTitle from '../../models/market/jobTitleModel';
-import { CreateJobTitlePayload, UpdateJobTitlePayload, JobTitleEmbeddingData } from '../../types/jobTitle.types';
-import { ImportanceLevel } from '../../../../shared/constants/jobsAndIndustries/constants';
-import { embeddingRegistry } from '../../infrastructure/embedding/registry/embeddingRegistry';
-import { orchestrateEmbeddings } from '../../infrastructure/embedding/core/orchestrateEmbedding';
-import { executeEmbeddingPipeline } from '../../infrastructure/embedding/core/executeEmbeddingPipeline';
-import { PythonEmit } from '../../types/python.types';
+import { isEmbeddingStale, isValidEmbedding } from '../../utils/embeddings/embeddingValidationUtils.js';
+import logger from '../../utils/logger.js';
+import { QueueJob } from '../../types/queues.types.js';
+import JobTitle from '../../models/market/jobTitleModel.js';
+import { CreateJobTitlePayload, UpdateJobTitlePayload, JobTitleEmbeddingData } from '../../types/jobTitle.types.js';
+import { ImportanceLevel } from '../../../../shared/constants/jobsAndIndustries/constants.js';
+import { embeddingRegistry } from '../../infrastructure/embedding/registry/embeddingRegistry.js';
+import { orchestrateEmbeddings } from '../../infrastructure/embedding/core/orchestrateEmbedding.js';
+import { executeEmbeddingPipeline } from '../../infrastructure/embedding/core/executeEmbeddingPipeline.js';
+import { PythonEmit } from '../../types/python.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/backend/src/services/market/locationService.ts
+++ b/backend/src/services/market/locationService.ts
@@ -1,14 +1,14 @@
 import { Types } from 'mongoose';
-import Location, { LocationDocument } from '../../models/market/locationModel';
-import * as LocationRepository from '../../repositories/market/locationRepositories';
-import logger from '../../utils/logger';
-import { isEmbeddingStale, isValidEmbedding } from '../../utils/embeddings/embeddingValidationUtils';
-import { QueueJob } from '../../types/queues.types';
-import { PythonEmit, PythonResponse, runPythonTyped } from '../../types/python.types';
-import { CreateLocationPayload, LocationEmbeddingData, UpdateLocationPayload } from '../../types/location.types';
-import { embeddingRegistry } from '../../infrastructure/embedding/registry/embeddingRegistry';
-import { orchestrateEmbeddings } from '../../infrastructure/embedding/core/orchestrateEmbedding';
-import { executeEmbeddingPipeline } from '../../infrastructure/embedding/core/executeEmbeddingPipeline';
+import Location, { LocationDocument } from '../../models/market/locationModel.js';
+import * as LocationRepository from '../../repositories/market/locationRepositories.js';
+import logger from '../../utils/logger.js';
+import { isEmbeddingStale, isValidEmbedding } from '../../utils/embeddings/embeddingValidationUtils.js';
+import { QueueJob } from '../../types/queues.types.js';
+import { PythonEmit, PythonResponse, runPythonTyped } from '../../types/python.types.js';
+import { CreateLocationPayload, LocationEmbeddingData, UpdateLocationPayload } from '../../types/location.types.js';
+import { embeddingRegistry } from '../../infrastructure/embedding/registry/embeddingRegistry.js';
+import { orchestrateEmbeddings } from '../../infrastructure/embedding/core/orchestrateEmbedding.js';
+import { executeEmbeddingPipeline } from '../../infrastructure/embedding/core/executeEmbeddingPipeline.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/backend/src/services/market/skillService.ts
+++ b/backend/src/services/market/skillService.ts
@@ -2,7 +2,7 @@ import * as SkillRepo from '../../repositories/market/skillRepositories.js';
 import { Types } from 'mongoose';
 import { isEmbeddingStale, isValidEmbedding } from '../../utils/embeddings/embeddingValidationUtils.js';
 import logger from '../../utils/logger.js';
-import { PythonEmit, PythonResponse, runPythonTyped } from '../../types/python.types.js';
+import { PythonEmit } from '../../types/python.types.js';
 import { QueueJob } from '../../types/queues.types.js';
 import Skill, { SkillDocument } from '../../models/market/skillModel.js';
 import { CreateSkillPayload, UpdateSkillPayload } from '../../types/skill.types.js';

--- a/backend/src/services/market/skillService.ts
+++ b/backend/src/services/market/skillService.ts
@@ -1,14 +1,14 @@
-import * as SkillRepo from '../../repositories/market/skillRepositories';
+import * as SkillRepo from '../../repositories/market/skillRepositories.js';
 import { Types } from 'mongoose';
-import { isEmbeddingStale, isValidEmbedding } from '../../utils/embeddings/embeddingValidationUtils';
-import logger from '../../utils/logger';
-import { PythonEmit, PythonResponse, runPythonTyped } from '../../types/python.types';
-import { QueueJob } from '../../types/queues.types';
-import Skill, { SkillDocument } from '../../models/market/skillModel';
-import { CreateSkillPayload, UpdateSkillPayload } from '../../types/skill.types';
-import { embeddingRegistry } from '../../infrastructure/embedding/registry/embeddingRegistry';
-import { orchestrateEmbeddings } from '../../infrastructure/embedding/core/orchestrateEmbedding';
-import { executeEmbeddingPipeline } from '../../infrastructure/embedding/core/executeEmbeddingPipeline';
+import { isEmbeddingStale, isValidEmbedding } from '../../utils/embeddings/embeddingValidationUtils.js';
+import logger from '../../utils/logger.js';
+import { PythonEmit, PythonResponse, runPythonTyped } from '../../types/python.types.js';
+import { QueueJob } from '../../types/queues.types.js';
+import Skill, { SkillDocument } from '../../models/market/skillModel.js';
+import { CreateSkillPayload, UpdateSkillPayload } from '../../types/skill.types.js';
+import { embeddingRegistry } from '../../infrastructure/embedding/registry/embeddingRegistry.js';
+import { orchestrateEmbeddings } from '../../infrastructure/embedding/core/orchestrateEmbedding.js';
+import { executeEmbeddingPipeline } from '../../infrastructure/embedding/core/executeEmbeddingPipeline.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/backend/src/services/resumes/resumeEmbeddingService.ts
+++ b/backend/src/services/resumes/resumeEmbeddingService.ts
@@ -1,14 +1,14 @@
 import { Types } from "mongoose";
 import { getResumeEmbeddingsRepo } from "../../repositories/resumes/resumeEmbeddingRepository.js";
-import { validateResumeEmbeddings } from "../../utils/embeddings/embeddingValidationUtils";
+import { validateResumeEmbeddings } from "../../utils/embeddings/embeddingValidationUtils.js";
 import logger from "../../utils/logger.js";
 import { UnauthorizedError } from "../../middleware/errorHandler.js";
-import { embeddingRegistry } from "../../infrastructure/embedding/registry/embeddingRegistry";
-import { orchestrateEmbeddings } from "../../infrastructure/embedding/core/orchestrateEmbedding";
-import { executeEmbeddingPipeline } from "../../infrastructure/embedding/core/executeEmbeddingPipeline";
+import { embeddingRegistry } from "../../infrastructure/embedding/registry/embeddingRegistry.js";
+import { orchestrateEmbeddings } from "../../infrastructure/embedding/core/orchestrateEmbedding.js";
+import { executeEmbeddingPipeline } from "../../infrastructure/embedding/core/executeEmbeddingPipeline.js";
 import { QueueJob } from "../../types/queues.types.js";
 import { ResumeEmbeddingsDocument } from "../../types/embeddings.types.js";
-import { executeEmbeddingFallback } from "../../infrastructure/embedding/core/executeEmbeddingFallback";
+import { executeEmbeddingFallback } from "../../infrastructure/embedding/core/executeEmbeddingFallback.js";
 import { PythonEmit } from "../../types/python.types.js";
 
 export const getOrGenerateResumeEmbeddingService = async (

--- a/backend/src/types/industry.types.ts
+++ b/backend/src/types/industry.types.ts
@@ -1,6 +1,6 @@
 // types/industry.types.ts
 import { Types } from "mongoose";
-import { INDUSTRY_NAMES, SENIORITY_LEVELS } from "../../../shared/constants/jobsAndIndustries/constants";
+import { INDUSTRY_NAMES, SENIORITY_LEVELS } from "../../../shared/constants/jobsAndIndustries/constants.js";
 import { Currency, SalaryBySeniority } from "./salaryTypes.js";
 import { EmbeddingVector } from "./embeddings.types.js";
 

--- a/backend/src/types/jobTitle.types.ts
+++ b/backend/src/types/jobTitle.types.ts
@@ -1,6 +1,6 @@
 // types/jobTitle.types.ts
 import { Types } from "mongoose";
-import { INDUSTRY_NAMES } from "../../../shared/constants/jobsAndIndustries/constants";
+import { INDUSTRY_NAMES } from "../../../shared/constants/jobsAndIndustries/constants.js";
 import { Currency, SalaryBySeniority, SalaryRange } from "./salaryTypes.js";
 import { SeniorityLevel } from "./industry.types.js";
 import { EmbeddingVector } from "./embeddings.types.js";

--- a/backend/src/types/python.types.ts
+++ b/backend/src/types/python.types.ts
@@ -1,4 +1,4 @@
-import { runPython } from "../infrastructure/python/pythonRunner";
+import { runPython } from "../infrastructure/python/pythonRunner.js";
 import { EmbeddingVector } from "./embeddings.types.js";
 
 export type PythonEmit = (

--- a/backend/src/utils/embeddings/embeddingValidationUtils.ts
+++ b/backend/src/utils/embeddings/embeddingValidationUtils.ts
@@ -1,4 +1,4 @@
-import { EmbeddingValidationReturn, EmbeddingVector, JobPostingEmbeddingsDocument, ResumeEmbeddingsDocument } from "../../types/embeddings.types";
+import { EmbeddingValidationReturn, EmbeddingVector, JobPostingEmbeddingsDocument, ResumeEmbeddingsDocument } from "../../types/embeddings.types.js";
 
 /**
  * Validates that a single embedding vector is usable.

--- a/backend/src/utils/queueUtils.ts
+++ b/backend/src/utils/queueUtils.ts
@@ -1,7 +1,7 @@
 import Redis from "ioredis";
-import { redisConnection } from "../config/queue.config";
+import { redisConnection } from "../config/queue.config.js";
 import logger from "./logger.js";
-import { QueueResult } from "../types/queues.types";
+import { QueueResult } from "../types/queues.types.js";
 
 type RedisState = 'healthy' | 'down' | 'unknown';
 

--- a/backend/src/utils/scoreValidationUtils.ts
+++ b/backend/src/utils/scoreValidationUtils.ts
@@ -1,4 +1,4 @@
-import { ResumeScoreDoc, ResumeScoreValidationReturn } from "../types/scores.types";
+import { ResumeScoreDoc, ResumeScoreValidationReturn } from "../types/scores.types.js";
 
 /**
  * Validates that a single score field is usable.

--- a/backend/src/utils/sendTypedResponse.ts
+++ b/backend/src/utils/sendTypedResponse.ts
@@ -1,5 +1,5 @@
 import { Response } from "express";
-import { ApiSendResponse } from "../types/apiResponse.types";
+import { ApiSendResponse } from "../types/apiResponse.types.js";
 
 export function sendTypedResponse<T>(
   res: Response,

--- a/backend/src/validators/jobTitleValidator.ts
+++ b/backend/src/validators/jobTitleValidator.ts
@@ -1,6 +1,6 @@
 // validators/market/jobTitleValidator.ts
 import Joi from "joi";
-import { SENIORITY_LEVELS, INDUSTRY_CHOICES } from "../../../shared/constants/jobsAndIndustries/constants";
+import { SENIORITY_LEVELS, INDUSTRY_CHOICES } from "../../../shared/constants/jobsAndIndustries/constants.js";
 
 export const jobTitleId = Joi.object({
   _id: Joi.string().hex().length(24).required()


### PR DESCRIPTION
…atibility

Relative imports in .ts files were missing explicit .js extensions, causing ERR_MODULE_NOT_FOUND errors on Render where tsx is not available to resolve extensionless imports. TypeScript's bundler mode and tsx handle this locally but Node ESM in production requires explicit extensions. Auto-fixed across all .ts files in backend/src using a bulk regex replacement.